### PR TITLE
General tooltip updates

### DIFF
--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -19,6 +19,11 @@
     overflow: overlay;
 }
 
+.overviewBars .tooltip {
+    display: flex;
+    align-items: center;
+}
+
 .overviewBars .tooltip.total rect {
     fill: #ececec;
     stroke: #ececec;
@@ -29,7 +34,7 @@
 .overviewBars .tooltip rect {
     fill: #ececec;
     stroke: #ececec;
-    width: 65px;
+    width: 83px;
     height: 22px;
 }
 
@@ -63,6 +68,7 @@
 
 #inputs .tooltip {
     visibility: hidden;
+
     transition: visibility 0.25s ease-in-out;
 }
 #inputs:hover .tooltip {

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -242,14 +242,14 @@ function Bar({
     const barPos2 = barPos1 + inputsHeight;
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 35})`}>
+            <g className="tooltip total" transform={`translate(${offset - 50},${height - totalHeight - 35})`}>
                 <rect rx="5" />
                 <text x="5" y="16">
                     {blockHeight}
                 </text>
             </g>
             <g id="kernels">
-                <g className="tooltip" transform={`translate(${offset - 70},${height - kernelHeight - 25})`}>
+                <g className="tooltip" transform={`translate(${offset - 90},${height - kernelHeight - 25})`}>
                     <rect rx="5" />
                     <text x="5" y="16">
                         {`${kernelsVal} kernel${kernelsVal > 1 ? 's' : ''}`}
@@ -258,8 +258,8 @@ function Bar({
                 <rect fill="#9330FF" width={elementSize} height={kernelHeight} x={offset} y={height - kernelHeight} />
             </g>
             <g id="outputs">
-                <g className="tooltip" transform={`translate(${offset - 70},${height - barPos1 - 10})`}>
-                    <rect rx="5" />
+                <g className="tooltip" transform={`translate(${offset - 90},${height - barPos1 - 10})`}>
+                    <rect rx="5"/>
                     <text x="5" y="16">
                         {`${outputsVal} output${outputsVal > 1 ? 's' : ''}`}
                     </text>
@@ -267,9 +267,9 @@ function Bar({
                 <rect fill="#B4C9F5" width={elementSize} height={outputHeight} x={offset} y={height - barPos1} />
             </g>
             <g id="inputs">
-                <g className="tooltip" transform={`translate(${offset - 70},${height - barPos2 - 5})`}>
+                <g className="tooltip" transform={`translate(${offset - 90},${height - barPos2 - 5})`}>
                     <rect rx="5" />
-                    <text x="5" y="16">
+                    <text x="5" textAnchor="start" y="16">
                         {`${inputsVal} input${inputsVal > 1 ? 's' : ''}`}
                     </text>
                 </g>

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -110,7 +110,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data }: Props)
                         <g key={i} className="barHolder">
                             <circle cx={item.x} cy={item.y} r="10" fill="#352583" fillOpacity="0" />
                             <g className="tooltip" opacity="0.9">
-                                <rect x={item.x - 20} y={item.y - 20} width="35" height="22" />
+                                <rect rx={5} x={item.x - 20} y={item.y - 20} width="35" height="22" />
                                 <text x={item.x - 15} y={item.y - 5}>
                                     {numeral(data[i].y).format('0a')}
                                 </text>


### PR DESCRIPTION
## Description

- Added rounded border to Network Difficulty tooltips
- Tweaked sizing on Hero Graph tooltips to accommodate 4 digits
- Tweaked offsets (to avoid it overlapping the bar)
- Tweaked `y` position of block height tooltip (to avoid overlapping on the smaller bars)

#### Screenshots

![image](https://user-images.githubusercontent.com/47271333/84156623-05df5880-aa6a-11ea-8e51-c3beb3bea029.png)


![image](https://user-images.githubusercontent.com/47271333/84155896-2b1f9700-aa69-11ea-906e-222bb3b9675b.png)

![image](https://user-images.githubusercontent.com/47271333/84155917-3246a500-aa69-11ea-86d9-df88f1c54012.png)


![image](https://user-images.githubusercontent.com/47271333/84155936-38d51c80-aa69-11ea-9db8-1be9f115012b.png)


