### PR TITLE
Additional Responsive updates to Graphs

### DIFF
--- a/src/components/Graphs/PolygonGraph.css
+++ b/src/components/Graphs/PolygonGraph.css
@@ -6,9 +6,9 @@
     transition: fill 0.2s;
 }
 .graphWrapper {
-    padding: 30px;
+    margin: 30px;
     border-radius: 5px;
-    max-width: 500px;
+    max-width: 40vw;
     overflow: hidden;
 }
 .simpleBars {
@@ -31,8 +31,36 @@
     width: 100% !important;
 }
 
+.networkDifficultyGraph {
+    margin: 30px;
+}
+
 .networkDifficultyPaths {
-    padding: 20px 60px 0 50px;
     overflow: overlay;
-    margin: 20px;
+    margin: 30px;
+    width: 100%;
+    height: auto;
+}
+
+.networkDifficultyGraph .xAxisDate {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    margin: 0 30px;
+    color: #adadad;
+}
+
+.networkDifficultyGraph .xAxisDate .tick {
+    font-family: Avenir, sans-serif;
+    font-size: 14px;
+    display: flex;
+    color: #adadad;
+}
+
+.xAxisLabel {
+    font-family: Avenir, sans-serif;
+    font-size: 12px;
+    color: #bababa;
+    text-align: center;
+    margin: 5px 0 0 30px;
 }

--- a/src/components/Graphs/PolygonGraph.css
+++ b/src/components/Graphs/PolygonGraph.css
@@ -42,7 +42,7 @@
     height: auto;
 }
 
-.networkDifficultyGraph .xAxisDate {
+.xAxisDate {
     display: flex;
     width: 100%;
     justify-content: space-between;
@@ -50,7 +50,7 @@
     color: #adadad;
 }
 
-.networkDifficultyGraph .xAxisDate .tick {
+.xAxisDate .tick {
     font-family: Avenir, sans-serif;
     font-size: 14px;
     display: flex;

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -52,7 +52,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                         style={{ fontFamily: 'Avenir, sans-serif', fontSize: 14, display: 'block' }}
                         key={`${i}-text`}
                         fill="#adadad"
-                        x={-50}
+                        x={-25}
                         y={(height / yAxisTicks) * i}
                     >
                         {numeral(displayNum).format('0a')}
@@ -88,14 +88,20 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
     }
 
     return (
-        <div className="graphWrapper">
+        <div className="graphWrapper networkDifficultyGraph">
             <PlainGraphTitle
                 title="Network Difficulty"
                 subTitle={`How difficult it is to mine a new block for the Tari blockchain.`}
             />
-            <svg className="networkDifficultyPaths" height={height} width={width}>
+            <svg
+                viewBox={`0 0 ${width} ${height}`}
+                preserveAspectRatio="xMidYMid meet"
+                className="networkDifficultyPaths"
+                height={height}
+                width={width}
+            >
                 <g className="yAxisLabel">
-                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 12 }} fill="#bababa" x={-130} y={-60}>
+                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 11 }} fill="#bababa" x={-120} y={-30}>
                         {yAxisLabel}
                     </text>
                 </g>
@@ -116,9 +122,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                     );
                 })}
             </svg>
-            <div className="xAxisDate" style={{ width: width - 50 }}>
-                {renderXAxis()}
-            </div>
+            <div className="xAxisDate">{renderXAxis()}</div>
             <div className="xAxisLabel">{xAxisLabel}</div>
         </div>
     );

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -52,7 +52,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                         style={{ fontFamily: 'Avenir, sans-serif', fontSize: 14, display: 'block' }}
                         key={`${i}-text`}
                         fill="#adadad"
-                        x={-25}
+                        x={-30}
                         y={(height / yAxisTicks) * i}
                     >
                         {numeral(displayNum).format('0a')}
@@ -101,7 +101,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                 width={width}
             >
                 <g className="yAxisLabel">
-                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 11 }} fill="#bababa" x={-120} y={-30}>
+                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 11 }} fill="#bababa" x={-120} y={-40}>
                         {yAxisLabel}
                     </text>
                 </g>

--- a/src/components/Graphs/SimpleBarGraph.css
+++ b/src/components/Graphs/SimpleBarGraph.css
@@ -45,24 +45,14 @@
     justify-content: space-between;
     align-self: center;
 }
+.circulateSimpleBarsWrapper {
+    margin: 30px;
+}
 .circulateSimpleBars {
-    padding: 20px 60px 0 50px;
     overflow: overlay;
-    margin: 20px;
-}
-
-.xAxisDate {
-    display: flex;
-    justify-items: center;
-    margin: 20px 20px 20px 70px;
-    justify-content: space-between;
-}
-
-.xAxisDate .tick {
-    font-family: Avenir, sans-serif;
-    font-size: 14px;
-    display: flex;
-    color: #adadad;
+    margin: 30px;
+    width: 100%;
+    height: auto;
 }
 
 .yAxisLabel {

--- a/src/components/Graphs/SimpleBarGraph.css
+++ b/src/components/Graphs/SimpleBarGraph.css
@@ -54,9 +54,8 @@
 .xAxisDate {
     display: flex;
     justify-items: center;
-    margin: 20px 20px 8px 70px;
+    margin: 20px 20px 20px 70px;
     justify-content: space-between;
-    color: #adadad;
 }
 
 .xAxisDate .tick {
@@ -70,13 +69,4 @@
     font-family: Avenir, sans-serif;
     font-size: 14px;
     transform: rotate(270deg);
-}
-
-.xAxisLabel {
-    font-family: Avenir, sans-serif;
-    font-size: 12px;
-    text-align: center;
-    color: #bababa;
-    margin: 0 auto;
-
 }

--- a/src/components/Graphs/SimpleBarGraph.tsx
+++ b/src/components/Graphs/SimpleBarGraph.tsx
@@ -74,7 +74,13 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
             />
 
             {/*<div className="yAxisLabel">{yAxisLabel}</div>*/}
-            <svg className="circulateSimpleBars" height={height} width={width}>
+            <svg
+                viewBox={`0 0 ${width} ${height}`}
+                preserveAspectRatio="xMidYMid meet"
+                className="circulateSimpleBars"
+                height={height}
+                width={width}
+            >
                 <g className="yAxisLabel">
                     <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 12 }} fill="#bababa" x={-130} y={-60}>
                         {yAxisLabel}

--- a/src/components/Graphs/SimpleBarGraph.tsx
+++ b/src/components/Graphs/SimpleBarGraph.tsx
@@ -41,7 +41,7 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
                         style={{ fontFamily: 'Avenir, sans-serif', fontSize: 14 }}
                         key={`${i}-text`}
                         fill="#adadad"
-                        x={-50}
+                        x={-30}
                         y={(height / yAxisTicks) * i}
                     >
                         {numeral(displayNum || 0).format('0a')}
@@ -67,7 +67,7 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
     const title = `Circulating ${tokenName}`;
     const yAxisLabel = `million ${tokenName}`;
     return (
-        <div className="graphWrapper">
+        <div className="graphWrapper circulateSimpleBarsWrapper">
             <PlainGraphTitle
                 title={title}
                 subTitle={`Total number of mined ${tokenName} circulating on the network.`}
@@ -82,7 +82,7 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
                 width={width}
             >
                 <g className="yAxisLabel">
-                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 12 }} fill="#bababa" x={-130} y={-60}>
+                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 11 }} fill="#bababa" x={-120} y={-40}>
                         {yAxisLabel}
                     </text>
                 </g>
@@ -114,7 +114,7 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
                     );
                 })}
             </svg>
-            <div className="xAxisDate" style={{ width: width - 50 }}>
+            <div className="xAxisDate">
                 <div className="tick">4 weeks ago</div>
                 <div className="tick">3 weeks ago</div>
                 <div className="tick">2 weeks ago</div>

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,32 @@ body {
     .xAxisTimes .tick {
         font-size: 10px;
     }
+
+    /*heroGraph End*/
+
+    .graphWrapper {
+        max-width: 85vw;
+        padding: 0;
+    }
+
+    /*network difficulty*/
+    .networkDifficultyPaths {
+        padding: 0;
+    }
+
+    .networkDifficultyGraph .xAxisDate {
+        width: auto;
+        margin: 0 0 0 30px;
+    }
+
+    .networkDifficultyGraph .xAxisDate .tick {
+        font-size: 11px;
+    }
+
+    .xAxisLabel {
+        font-size: 9px;
+    }
+
     /*Graphs end*/
 }
 


### PR DESCRIPTION
## Description 

- Updated the Network Difficulty & Circulating Tari Graphs to be able to scale
- Minor css tweaks

### Notes
- The x-axis on the Circulating Tari Graph is a bit wonky on mobile as the text gets a bit lengthly. (see screenshot below) I have left it as is for now because we will be updating the axes to adjust based on the drop downs so we can agree new copy for the ticks then?

## Screenshots
![image](https://user-images.githubusercontent.com/47271333/84414827-4ed21100-ac12-11ea-9ab0-deb047410f18.png)


![image](https://user-images.githubusercontent.com/47271333/84414135-d408f600-ac11-11ea-935e-f21bd2e29d18.png)

Long text on x-axis:

![image](https://user-images.githubusercontent.com/47271333/84414975-64dfd180-ac12-11ea-82e8-24cc0b5f8868.png)

