### PR TITLE
Tooltip & General styling updates 

### DIFF
--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -9,11 +9,8 @@
     display: flex;
     justify-items: center;
     margin-bottom: 2rem;
-
-    /*padding: 0 20px 20px 60px;*/
     justify-content: space-between;
 }
-
 .xAxisTimes {
     width: 100%;
 }
@@ -23,12 +20,10 @@
     display: flex;
     color: #adadad;
 }
-
 .heroYAxisText {
     font-family: Avenir, sans-serif;
     font-size: 0.6em;
 }
-
 .heroBars {
     margin-bottom: 2rem;
     overflow: overlay;
@@ -36,10 +31,7 @@
     height: auto;
 }
 
-.overviewBars .tooltip {
-    display: flex;
-    align-items: center;
-}
+/*block height tooltip*/
 
 .overviewBars .tooltip.total rect {
     fill: #ececec;
@@ -48,77 +40,72 @@
     height: 13px;
 }
 
-.overviewBars .tooltip rect {
-    fill: #ececec;
-    stroke: #ececec;
-    width: 83px;
-    height: 22px;
-}
-
 .overviewBars .tooltip text {
     fill: #9330ff;
     font-size: 9px;
     font-family: Avenir, sans-serif;
     font-weight: bold;
 }
-
 .overviewBars .tooltip.total {
     visibility: hidden;
     transition: visibility 0.25s ease-in-out;
 }
-
 .overviewBars:hover .tooltip.total {
     visibility: visible;
 }
 
-.overviewBars.first {
-    transition: all 3s ease-in-out;
+/*block height tooltip end*/
+
+/*bars tooltips*/
+
+.overviewBars .tooltip {
+    display: flex;
+    align-items: center;
 }
 
+.overviewBars .tooltip rect {
+    fill: #ececec;
+    stroke: #ececec;
+    width: 60px;
+    height: 15px;
+}
+
+#inputs .tooltip text,
+#outputs .tooltip text,
+#kernels .tooltip text {
+    font-size: 9px;
+    font-family: Avenir, sans-serif;
+    font-weight: bold;
+}
+
+#inputs .tooltip,
+#outputs .tooltip,
 #kernels .tooltip {
     visibility: hidden;
     transition: visibility 0.25s ease-in-out;
 }
+
+#inputs:hover .tooltip,
+#outputs:hover .tooltip,
 #kernels:hover .tooltip {
     visibility: visible;
 }
 
 #kernels .tooltip text {
     fill: #9330ff;
-    font-size: 12px;
-    font-family: Avenir, sans-serif;
-    font-weight: bold;
 }
-
-#inputs .tooltip {
-    visibility: hidden;
-
-    transition: visibility 0.25s ease-in-out;
-}
-#inputs:hover .tooltip {
-    visibility: visible;
-}
-
-#inputs .tooltip text {
-    fill: #ff7630;
-    font-size: 12px;
-    font-family: Avenir, sans-serif;
-    font-weight: bold;
-}
-
-#outputs .tooltip {
-    visibility: hidden;
-    transition: visibility 0.25s ease-in-out;
-}
-#outputs:hover .tooltip {
-    visibility: visible;
-}
-
 #outputs .tooltip text {
     fill: #b4c9f5;
-    font-size: 12px;
-    font-family: Avenir, sans-serif;
-    font-weight: bold;
+}
+#inputs .tooltip text {
+    fill: #ff7630;
+}
+/*bars tt end*/
+
+/*animation*/
+
+.overviewBars.first {
+    transition: all 3s ease-in-out;
 }
 
 .animate:first-child {
@@ -133,3 +120,5 @@
         transform: rotate(0deg);
     }
 }
+
+/*animation end*/

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -66,7 +66,7 @@
 .overviewBars .tooltip rect {
     fill: #ececec;
     stroke: #ececec;
-    width: 60px;
+    width: 63px;
     height: 15px;
 }
 

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -31,7 +31,6 @@
 
 .heroBars {
     margin-bottom: 2rem;
-    /*padding: 10px 20px 0 60px;*/
     overflow: overlay;
     width: 100%;
     height: auto;
@@ -45,8 +44,8 @@
 .overviewBars .tooltip.total rect {
     fill: #ececec;
     stroke: #ececec;
-    width: 45px;
-    height: 22px;
+    width: 35px;
+    height: 13px;
 }
 
 .overviewBars .tooltip rect {
@@ -54,6 +53,13 @@
     stroke: #ececec;
     width: 83px;
     height: 22px;
+}
+
+.overviewBars .tooltip text {
+    fill: #9330ff;
+    font-size: 9px;
+    font-family: Avenir, sans-serif;
+    font-weight: bold;
 }
 
 .overviewBars .tooltip.total {

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import './HeroGraph.css';
 import { ReactComponent as Bars } from '../../assets/bars.svg';
 import { connect } from 'react-redux';
+import { leftPad } from '../../helpers/leftPad';
 
 interface Props {
     blocks: any[];
@@ -245,6 +246,17 @@ function Bar({
 
     const barPos1 = outputHeight + kernelHeight;
     const barPos2 = barPos1 + inputsHeight;
+
+    function getTooltipText(value, type) {
+        let text = '';
+        if (value > 1) {
+            text = `${value} ${type}s`;
+        } else {
+            text = `${value} ${type}`;
+        }
+        return leftPad(text, 13, ' ');
+    }
+
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
             <g className="tooltip total" transform={`translate(${offset - 30},${height - totalHeight - 25})`}>
@@ -256,8 +268,8 @@ function Bar({
             <g id="kernels">
                 <g className="tooltip" transform={`translate(${offset - 65},${height - kernelHeight - 25})`}>
                     <rect rx="3" />
-                    <text x="5" y="11">
-                        {`${kernelsVal} kernel${kernelsVal > 1 ? 's' : ''}`}
+                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
+                        {getTooltipText(kernelsVal, 'kernel')}
                     </text>
                 </g>
                 <rect fill="#9330FF" width={elementSize} height={kernelHeight} x={offset} y={height - kernelHeight} />
@@ -265,8 +277,8 @@ function Bar({
             <g id="outputs">
                 <g className="tooltip" transform={`translate(${offset - 65},${height - barPos1 - 10})`}>
                     <rect rx="3" />
-                    <text x="5" y="11">
-                        {`${outputsVal} output${outputsVal > 1 ? 's' : ''}`}
+                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
+                        {getTooltipText(outputsVal, 'output')}
                     </text>
                 </g>
                 <rect fill="#B4C9F5" width={elementSize} height={outputHeight} x={offset} y={height - barPos1} />
@@ -274,8 +286,8 @@ function Bar({
             <g id="inputs">
                 <g className="tooltip" transform={`translate(${offset - 65},${height - barPos2 - 5})`}>
                     <rect rx="3" />
-                    <text x="5" textAnchor="start" y="11">
-                        {`${inputsVal} input${inputsVal > 1 ? 's' : ''}`}
+                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
+                        {getTooltipText(inputsVal, 'input')}
                     </text>
                 </g>
                 <rect

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -70,7 +70,6 @@ function HeroGraph({ yAxisTicks, blocks }: Props) {
         };
     });
 
-    // blocksData.sort((a, b) => b.blockHeight - a.blockHeight);
     const maxHeights = getHighest(blocksData);
     function renderYAxis(maxHeights: HeightBar) {
         const nums: any[] = [];
@@ -248,14 +247,14 @@ function Bar({
     const barPos2 = barPos1 + inputsHeight;
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 50},${height - totalHeight - 25})`}>
+            <g className="tooltip total" transform={`translate(${offset - 30},${height - totalHeight - 25})`}>
                 <rect rx="3" />
                 <text x="4" y="10">
                     {blockHeight}
                 </text>
             </g>
             <g id="kernels">
-                <g className="tooltip" transform={`translate(${offset - 90},${height - kernelHeight - 25})`}>
+                <g className="tooltip" transform={`translate(${offset - 65},${height - kernelHeight - 25})`}>
                     <rect rx="3" />
                     <text x="5" y="11">
                         {`${kernelsVal} kernel${kernelsVal > 1 ? 's' : ''}`}
@@ -264,7 +263,7 @@ function Bar({
                 <rect fill="#9330FF" width={elementSize} height={kernelHeight} x={offset} y={height - kernelHeight} />
             </g>
             <g id="outputs">
-                <g className="tooltip" transform={`translate(${offset - 90},${height - barPos1 - 10})`}>
+                <g className="tooltip" transform={`translate(${offset - 65},${height - barPos1 - 10})`}>
                     <rect rx="3" />
                     <text x="5" y="11">
                         {`${outputsVal} output${outputsVal > 1 ? 's' : ''}`}
@@ -273,7 +272,7 @@ function Bar({
                 <rect fill="#B4C9F5" width={elementSize} height={outputHeight} x={offset} y={height - barPos1} />
             </g>
             <g id="inputs">
-                <g className="tooltip" transform={`translate(${offset - 90},${height - barPos2 - 5})`}>
+                <g className="tooltip" transform={`translate(${offset - 65},${height - barPos2 - 5})`}>
                     <rect rx="3" />
                     <text x="5" textAnchor="start" y="11">
                         {`${inputsVal} input${inputsVal > 1 ? 's' : ''}`}

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -23,7 +23,7 @@ const dimensions = {
     width: 900,
     height: 280,
     margin: 10,
-    elementSize: 3
+    elementSize: 4
 } as const;
 
 function getHighest(values: Array<HeightBar>): HeightBar {
@@ -248,9 +248,9 @@ function Bar({
     const barPos2 = barPos1 + inputsHeight;
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 50},${height - totalHeight - 35})`}>
+            <g className="tooltip total" transform={`translate(${offset - 50},${height - totalHeight - 25})`}>
                 <rect rx="5" />
-                <text x="5" y="16">
+                <text x="4" y="10">
                     {blockHeight}
                 </text>
             </g>

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -249,15 +249,15 @@ function Bar({
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
             <g className="tooltip total" transform={`translate(${offset - 50},${height - totalHeight - 25})`}>
-                <rect rx="5" />
+                <rect rx="3" />
                 <text x="4" y="10">
                     {blockHeight}
                 </text>
             </g>
             <g id="kernels">
                 <g className="tooltip" transform={`translate(${offset - 90},${height - kernelHeight - 25})`}>
-                    <rect rx="5" />
-                    <text x="5" y="16">
+                    <rect rx="3" />
+                    <text x="5" y="11">
                         {`${kernelsVal} kernel${kernelsVal > 1 ? 's' : ''}`}
                     </text>
                 </g>
@@ -265,8 +265,8 @@ function Bar({
             </g>
             <g id="outputs">
                 <g className="tooltip" transform={`translate(${offset - 90},${height - barPos1 - 10})`}>
-                    <rect rx="5" />
-                    <text x="5" y="16">
+                    <rect rx="3" />
+                    <text x="5" y="11">
                         {`${outputsVal} output${outputsVal > 1 ? 's' : ''}`}
                     </text>
                 </g>
@@ -274,8 +274,8 @@ function Bar({
             </g>
             <g id="inputs">
                 <g className="tooltip" transform={`translate(${offset - 90},${height - barPos2 - 5})`}>
-                    <rect rx="5" />
-                    <text x="5" textAnchor="start" y="16">
+                    <rect rx="3" />
+                    <text x="5" textAnchor="start" y="11">
                         {`${inputsVal} input${inputsVal > 1 ? 's' : ''}`}
                     </text>
                 </g>

--- a/src/components/Graphs/PolygonGraph.css
+++ b/src/components/Graphs/PolygonGraph.css
@@ -64,3 +64,27 @@
     text-align: center;
     margin: 5px 0 0 30px;
 }
+
+/*tooltips*/
+
+.shapeHolder .tooltip {
+    visibility: hidden;
+}
+.shapeHolder:hover .tooltip {
+    visibility: visible;
+}
+.shapeHolder .tooltip text {
+    fill: #9330ff;
+    font-size: 10px;
+    font-family: Avenir, sans-serif;
+    font-weight: bold;
+}
+.shapeHolder .tooltip.blockHeightTooltip text {
+    fill: #ff7630;
+}
+.shapeHolder .tooltip rect {
+    fill: #ececec;
+    stroke: #ececec;
+    height: 18px;
+}
+/*tooltips end*/

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -17,12 +17,13 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
     const YHighestNum = Math.max(...data.map((o) => o.y));
     const XHighestNumber = Math.max(...data.map((o) => o.x));
     const XLowestNumber = Math.min(...data.map((o) => o.x));
-    const xScale = d3.scaleLinear().domain([XLowestNumber, XHighestNumber]).range([0, width]);
+    const xScale = d3.scaleLinear().domain([XHighestNumber, XLowestNumber]).range([0, width]);
     const yScale = d3.scaleLinear().domain([0, YHighestNum]).range([height, 0]);
     const transformedData = data.map((d, i) => {
         return {
             x: xScale(d.x),
-            y: yScale(d.y)
+            y: yScale(d.y),
+            blockHeight: d.x
         };
     });
 
@@ -84,7 +85,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                 </div>
             );
         }
-        return nums.sort();
+        return nums;
     }
 
     return (
@@ -110,12 +111,18 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
                 <path style={{ fill: '#F0EFF6', opacity: 0.5, strokeWidth: 0 }} d={areaGenerator(transformedData)} />
                 {transformedData.map((item, i) => {
                     return (
-                        <g key={i} className="barHolder">
-                            <circle cx={item.x} cy={item.y} r="10" fill="#352583" fillOpacity="0" />
+                        <g key={i} className="shapeHolder">
+                            <circle cx={item.x} cy={item.y} r="15" fill="#352583" fillOpacity="0" />
                             <g className="tooltip" opacity="0.9">
-                                <rect rx={5} x={item.x - 20} y={item.y - 20} width="35" height="22" />
-                                <text x={item.x - 15} y={item.y - 5}>
+                                <rect rx={3} x={item.x - 20} y={item.y - 20} width="25" />
+                                <text x={item.x - 16} y={item.y - 7}>
                                     {numeral(data[i].y || 0).format('0a')}
+                                </text>
+                            </g>
+                            <g className="tooltip blockHeightTooltip" opacity="0.9">
+                                <rect rx={3} x={item.x - 35} y={item.y - 45} width="40" />
+                                <text x={item.x - 31} y={item.y - 32}>
+                                    {item.blockHeight}
                                 </text>
                             </g>
                         </g>

--- a/src/components/Graphs/SimpleBarGraph.css
+++ b/src/components/Graphs/SimpleBarGraph.css
@@ -12,15 +12,16 @@
 .barHolder:hover .tooltip {
     visibility: visible;
 }
-.tooltip text {
+.barHolder .tooltip text {
     fill: #9330ff;
-    font-size: 12px;
+    font-size: 10px;
     font-family: Avenir, sans-serif;
     font-weight: bold;
 }
 .tooltip rect {
     fill: #ececec;
     stroke: #ececec;
+    height: 18px;
 }
 
 .graphWrapper {

--- a/src/components/Graphs/SimpleBarGraph.tsx
+++ b/src/components/Graphs/SimpleBarGraph.tsx
@@ -73,7 +73,6 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
                 subTitle={`Total number of mined ${tokenName} circulating on the network.`}
             />
 
-            {/*<div className="yAxisLabel">{yAxisLabel}</div>*/}
             <svg
                 viewBox={`0 0 ${width} ${height}`}
                 preserveAspectRatio="xMidYMid meet"
@@ -97,8 +96,8 @@ export default function SimpleBarGraph({ width, height, data, yAxisTicks }: Prop
                                 transform={`translate(${i * barWidth - 30},${yScale(total) - 30})`}
                                 opacity="0.9"
                             >
-                                <rect rx="5" width="35" height="22" />
-                                <text x="5" y="16">
+                                <rect rx="3" width="25" />
+                                <text x="3" y="13">
                                     {numeral(displayTotal || 0).format('0a')}
                                 </text>
                             </g>

--- a/src/helpers/leftPad.ts
+++ b/src/helpers/leftPad.ts
@@ -1,6 +1,6 @@
 const cache = ['', ' ', '  ', '   ', '    ', '     ', '      ', '       ', '        ', '         '];
 
-export function leftPad(str: any, len: any, ch: any): any {
+export function leftPad(str: string, len: number, ch: string): string {
     // convert `str` to a `string`
     str = str + '';
     // `len` is the `pad`'s length now

--- a/src/helpers/leftPad.ts
+++ b/src/helpers/leftPad.ts
@@ -1,0 +1,34 @@
+const cache = ['', ' ', '  ', '   ', '    ', '     ', '      ', '       ', '        ', '         '];
+
+export function leftPad(str: any, len: any, ch: any): any {
+    // convert `str` to a `string`
+    str = str + '';
+    // `len` is the `pad`'s length now
+    len = len - str.length;
+    // doesn't need to pad
+    if (len <= 0) return str;
+    // `ch` defaults to `' '`
+    if (!ch) ch = ' ';
+    // convert `ch` to a `string` cuz it could be a number
+    ch = ch + '';
+    // cache common use cases
+    if (ch === ' ' && len < 10) return cache[len] + str;
+    // `pad` starts with an empty string
+    let pad = '';
+    // loop
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        // add `ch` to `pad` if `len` is odd
+        if (len & 1) pad += ch;
+        // divide `len` by 2, ditch the remainder
+        len >>= 1;
+        // "double" the `ch` so this operation count grows logarithmically on `len`
+        // each time `ch` is "doubled", the `len` would need to be "doubled" too
+        // similar to finding a value in binary search tree, hence O(log(n))
+        if (len) ch += ch;
+        // `len` is 0, exit the loop
+        else break;
+    }
+    // pad `str`!
+    return pad + str;
+}

--- a/src/helpers/leftPad.ts
+++ b/src/helpers/leftPad.ts
@@ -1,6 +1,6 @@
 const cache = ['', ' ', '  ', '   ', '    ', '     ', '      ', '       ', '        ', '         '];
 
-export function leftPad(str: any, len: any, ch: any): any {
+export function leftPad(str: string, len: number, ch: string): any {
     // convert `str` to a `string`
     str = str + '';
     // `len` is the `pad`'s length now


### PR DESCRIPTION
## Description

- Updated tooltip styling that wonked out and got too large due to the scaling
- Minor refactoring of the CSS
- Added Block Height tooltip to Network Difficulty Graph
- Updated order/direction of Network Difficulty Graph
- Centering the Hero Graph tool tip text

#### Screenshots & videos

Hero graph updated tooltips:
![image](https://user-images.githubusercontent.com/47271333/84483185-42dd6200-ac99-11ea-8264-cb16ad43ec7a.png)

![image](https://user-images.githubusercontent.com/47271333/84489178-8f2ca000-aca1-11ea-9460-54152a24483d.png)

https://share.getcloudapp.com/GGuoANg0

Network difficulty tooltips and order:
(Block height tooltip lines up with x-axis block height tick)

![image](https://user-images.githubusercontent.com/47271333/84483432-9c459100-ac99-11ea-931e-bdb92e5019e8.png)

Updated tooltips on Circulating Tari Graph: 

![image](https://user-images.githubusercontent.com/47271333/84483506-b4b5ab80-ac99-11ea-8263-3c07760f5176.png)


