### PR TITLE
Updated x-position of tooltip

### DIFF
--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -257,7 +257,7 @@ function Bar({
 
     return (
         <g key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 30},${height - totalHeight - 30})`}>
+            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 30})`}>
                 <rect rx="3" />
                 <text x="4" y="10" xmlSpace="preserve" textAnchor="start">
                     {leftPad(timeAgo, 14, ' ')}


### PR DESCRIPTION
## Description

- Updated tooltip positioning to avoid overlap due to bigger size

#### Screenshots

Before : 
![image](https://user-images.githubusercontent.com/47271333/84656594-36fcd480-af13-11ea-9096-27609634346a.png)

After: 
![image](https://user-images.githubusercontent.com/47271333/84656613-3f550f80-af13-11ea-804f-dfd5c40f46ea.png)

