### PR TITLE
TopBar QA Tweaks

### DIFF
--- a/src/components/SideBar.css
+++ b/src/components/SideBar.css
@@ -1,21 +1,21 @@
 .SideBar {
-  border-right: 1px solid #d8d8d8;
-  width: 100px;
+    border-right: 1px solid #d8d8d8;
+    width: 90px;
 }
 
 .SideBar-navigationItem {
-  align-items: center;
-  cursor: pointer;
-  display: flex;
-  height: 100px;
-  justify-content: center;
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    height: 100px;
+    justify-content: center;
 }
 
 .SideBar-navigationItem > svg {
-  fill: #c2bfe7;
-  transition: fill 288ms;
+    fill: #c2bfe7;
+    transition: fill 288ms;
 }
 
 .SideBar-navigationItem:hover > svg {
-  fill: #372786;
+    fill: #372786;
 }

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -9,7 +9,7 @@
     border-right: 1px solid #d8d8d8;
     display: flex;
     justify-content: center;
-    width: 100px;
+    width: 90px;
     padding: 10px 0;
 }
 
@@ -32,7 +32,10 @@
 
 .TopBar-itemContainer > * {
     margin-left: 3em;
-    min-height: 70px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
 }
 
 .TopBar-itemContainer div:first-child {

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,8 @@ body {
     .TopBar-itemContainer div:first-child,
     .TopBar-itemContainer div {
         margin: 0;
+        align-items: flex-start;
+
     }
     .TopBar-searchContainer {
         justify-content: center;


### PR DESCRIPTION
## Description

- Right aligned stats (please note that for mobile I've kept it as left aligned and centered)
- Vertically centered the stats
- TopBar and left side bar are the same size and smaller

#### Related issues
Closes tari-project/block-explorer-frontend#67

#### Screenshots

Before: 
![image](https://user-images.githubusercontent.com/47271333/84876975-30dc3480-b088-11ea-91a1-ce2e7be7e14c.png)


After: 

![image](https://user-images.githubusercontent.com/47271333/84876916-1dc96480-b088-11ea-923d-b3354cffc3e6.png)
