### PR TITLE
QA Updates - Hero tooltips

### DIFF
--- a/src/components/BlockCard.tsx
+++ b/src/components/BlockCard.tsx
@@ -3,10 +3,8 @@ import './BlockCard.css';
 import numeral from 'numeral';
 import { Link } from 'react-router-dom';
 import * as timeago from 'timeago.js';
+import { fmtMSS } from '../helpers/fmtMSS';
 
-function fmtMSS(s) {
-    return (s - (s %= 60)) / 60 + (9 < s ? ':' : ':0') + s;
-}
 export default function BlockCard({ block }: { block: any }) {
     const {
         _miningTime,

--- a/src/components/Graphs/ClusterGraph.css
+++ b/src/components/Graphs/ClusterGraph.css
@@ -14,8 +14,12 @@
     margin: 0 auto;
 }
 
+.bubble {
+    stroke-width: 0;
+}
 .bubble:hover {
-    stroke: black;
+    stroke-width: 2;
+    stroke: #d5d5d5;
 }
 
 .tooltip {
@@ -23,4 +27,6 @@
     z-index: 1070;
     display: block;
     margin: 0;
+    font-family: Avenir, sans-serif;
+    font-weight: bold;
 }

--- a/src/components/Graphs/ClusterGraph.tsx
+++ b/src/components/Graphs/ClusterGraph.tsx
@@ -53,17 +53,19 @@ export default function ClusterGraph({ width, height, data }: Props) {
                 .append('div')
                 .style('opacity', 0)
                 .attr('class', 'tooltip')
-                .style('background-color', 'black')
+                .style('background-color', '#ececec')
                 .style('border-radius', '5px')
-                .style('padding', '10px')
-                .style('color', 'white');
+                .style('padding', '8px');
+
             const showTooltip = function (this: any, d) {
                 tooltip.transition().duration(200);
                 tooltip
-                    .style('opacity', 1)
+                    .style('opacity', 0.8)
                     .html(d.tooltip)
                     .style('left', d3.mouse(this)[0] + 30 + 'px')
-                    .style('top', d3.mouse(this)[1] + 30 + 'px');
+
+                    .style('top', d3.mouse(this)[1] + 30 + 'px')
+                    .style('color', d.color);
             };
             const moveTooltip = function (this: any, d) {
                 tooltip.style('left', d3.mouse(this)[0] + 30 + 'px').style('top', d3.mouse(this)[1] + 30 + 'px');
@@ -82,6 +84,9 @@ export default function ClusterGraph({ width, height, data }: Props) {
                     return radiusScale(d.size) * 4;
                 })
                 .attr('fill', function (d: any) {
+                    return d.color;
+                })
+                .attr('stroke', function (d: any) {
                     return d.color;
                 })
                 .attr('cx', 100)

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -52,10 +52,10 @@
     fill: #191145;
     /*fill: #ececec;*/
     stroke: #a5a5a5;
-    stroke-width: .5;
+    stroke-width: 0.5;
     width: 65px;
     height: 70px;
-    opacity: .8;
+    opacity: 0.8;
 }
 
 .overviewBars .tooltip text {
@@ -107,27 +107,6 @@
     width: 63px;
     height: 15px;
 }
-
-/*#inputs .tooltip text,*/
-/*#outputs .tooltip text,*/
-/*#kernels .tooltip text {*/
-/*    font-size: 9px;*/
-/*    font-family: Avenir, sans-serif;*/
-/*    font-weight: bold;*/
-/*}*/
-
-/*#inputs .tooltip,*/
-/*#outputs .tooltip,*/
-/*#kernels .tooltip {*/
-/*    visibility: hidden;*/
-/*    transition: visibility 0.25s ease-in-out;*/
-/*}*/
-
-/*#inputs:hover .tooltip,*/
-/*#outputs:hover .tooltip,*/
-/*#kernels:hover .tooltip {*/
-/*    visibility: visible;*/
-/*}*/
 
 #kernels .tooltip text {
     fill: #9330ff;

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -54,7 +54,7 @@
     stroke: #a5a5a5;
     stroke-width: .5;
     width: 65px;
-    height: 60px;
+    height: 70px;
     opacity: .8;
 }
 

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -4,6 +4,7 @@
     flex-direction: column;
     align-items: flex-start;
     margin: 30px;
+    max-height: 360px;
 }
 .xAxisTimes {
     display: flex;
@@ -37,7 +38,7 @@
     }
 }
 
-@media not all and (min-resolution:.001dpcm) {
+@media not all and (min-resolution: 0.001dpcm) {
     @media {
         .heroBars {
             overflow: visible;
@@ -48,10 +49,13 @@
 /*block height tooltip*/
 
 .overviewBars .tooltip.total rect {
-    fill: #ececec;
-    stroke: #ececec;
-    width: 75px;
-    height: 13px;
+    fill: #191145;
+    /*fill: #ececec;*/
+    stroke: #a5a5a5;
+    stroke-width: .5;
+    width: 65px;
+    height: 60px;
+    opacity: .8;
 }
 
 .overviewBars .tooltip text {
@@ -62,10 +66,30 @@
 }
 .overviewBars .tooltip.total {
     visibility: hidden;
+
     transition: visibility 0.25s ease-in-out;
 }
 .overviewBars:hover .tooltip.total {
     visibility: visible;
+}
+
+.overviewBars .tooltip.total text tspan.timeAgo {
+    fill: #a5a5a5;
+    font-size: 7px;
+}
+.overviewBars .tooltip.total text tspan.blockHeight {
+    fill: #90aab4;
+    font-size: 11px;
+}
+
+.overviewBars .tooltip.total text tspan.kernels {
+    fill: #9330ff;
+}
+.overviewBars .tooltip.total text tspan.outputs {
+    fill: #b4c9f5;
+}
+.overviewBars .tooltip.total text tspan.inputs {
+    fill: #ff7630;
 }
 
 /*block height tooltip end*/
@@ -84,26 +108,26 @@
     height: 15px;
 }
 
-#inputs .tooltip text,
-#outputs .tooltip text,
-#kernels .tooltip text {
-    font-size: 9px;
-    font-family: Avenir, sans-serif;
-    font-weight: bold;
-}
+/*#inputs .tooltip text,*/
+/*#outputs .tooltip text,*/
+/*#kernels .tooltip text {*/
+/*    font-size: 9px;*/
+/*    font-family: Avenir, sans-serif;*/
+/*    font-weight: bold;*/
+/*}*/
 
-#inputs .tooltip,
-#outputs .tooltip,
-#kernels .tooltip {
-    visibility: hidden;
-    transition: visibility 0.25s ease-in-out;
-}
+/*#inputs .tooltip,*/
+/*#outputs .tooltip,*/
+/*#kernels .tooltip {*/
+/*    visibility: hidden;*/
+/*    transition: visibility 0.25s ease-in-out;*/
+/*}*/
 
-#inputs:hover .tooltip,
-#outputs:hover .tooltip,
-#kernels:hover .tooltip {
-    visibility: visible;
-}
+/*#inputs:hover .tooltip,*/
+/*#outputs:hover .tooltip,*/
+/*#kernels:hover .tooltip {*/
+/*    visibility: visible;*/
+/*}*/
 
 #kernels .tooltip text {
     fill: #9330ff;

--- a/src/components/Graphs/HeroGraph.css
+++ b/src/components/Graphs/HeroGraph.css
@@ -4,7 +4,7 @@
     flex-direction: column;
     align-items: flex-start;
     margin: 30px;
-    max-height: 360px;
+    /*max-height: 360px; will revisit*/
 }
 .xAxisTimes {
     display: flex;

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -261,49 +261,45 @@ function Bar({
 
     function getTooltipText(value, type) {
         let text = '';
-        if (value > 1) {
-            text = `${value} ${type}s`;
-        } else {
+        if (value === 1) {
             text = `${value} ${type}`;
+        } else {
+            text = `${value} ${type}s`;
         }
-        return leftPad(text, 13, ' ');
+        return leftPad(text, 14, ' ');
     }
 
     const timeAgo = timeago.format(timestamp * 1000);
 
     return (
         <Link to={`/block/${hash}`} key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 30})`}>
+            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 35})`}>
                 <rect rx="3" />
-                <text x="4" y="10" xmlSpace="preserve" textAnchor="start">
-                    {leftPad(timeAgo, 14, ' ')}
+                <text x="60" y="10" xmlSpace="preserve" textAnchor="end">
+                    <tspan className="timeAgo" x="60" dy="0">
+                        {leftPad(timeAgo, 14, ' ')}
+                    </tspan>
+                    <tspan className="blockHeight" x="60" dy="14">
+                        {leftPad(`${blockHeight}`, 14, ' ')}
+                    </tspan>
+                    <tspan className="inputs" x="60" dy="12">
+                        {getTooltipText(inputsVal, 'input')}
+                    </tspan>
+                    <tspan className="outputs" x="60" dy="10">
+                        {getTooltipText(outputsVal, 'output')}
+                    </tspan>
+                    <tspan className="kernels" x="60" dy="10">
+                        {getTooltipText(kernelsVal, 'kernel')}
+                    </tspan>
                 </text>
             </g>
             <g id="kernels">
-                <g className="tooltip" transform={`translate(${offset - 65},${height - kernelHeight - 20})`}>
-                    <rect rx="3" />
-                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
-                        {getTooltipText(kernelsVal, 'kernel')}
-                    </text>
-                </g>
                 <rect fill="#9330FF" width={elementSize} height={kernelHeight} x={offset} y={height - kernelHeight} />
             </g>
             <g id="outputs">
-                <g className="tooltip" transform={`translate(${offset - 65},${height - barPos1 - 10})`}>
-                    <rect rx="3" />
-                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
-                        {getTooltipText(outputsVal, 'output')}
-                    </text>
-                </g>
                 <rect fill="#B4C9F5" width={elementSize} height={outputHeight} x={offset} y={height - barPos1} />
             </g>
             <g id="inputs">
-                <g className="tooltip" transform={`translate(${offset - 65},${height - barPos2 - 5})`}>
-                    <rect rx="3" />
-                    <text x="0" xmlSpace="preserve" textAnchor="start" y="11">
-                        {getTooltipText(inputsVal, 'input')}
-                    </text>
-                </g>
                 <rect
                     transform={`rotate(180 ${offset + elementSize / 2} ${height - barPos2 + inputsHeight / 2})`}
                     fill="#FF7630"

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -24,7 +24,7 @@ interface HeightBar {
 
 const dimensions = {
     width: 900,
-    height: 280,
+    height: 180,
     margin: 10,
     elementSize: 4
 } as const;

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -3,6 +3,7 @@ import './HeroGraph.css';
 import { ReactComponent as LoadingBars } from '../../assets/bars.svg';
 import { connect } from 'react-redux';
 import { leftPad } from '../../helpers/leftPad';
+import { fmtMSS } from '../../helpers/fmtMSS';
 import * as timeago from 'timeago.js';
 import { Link } from 'react-router-dom';
 
@@ -21,6 +22,7 @@ interface HeightBar {
     kernels: number;
     total: number;
     timestamp: number;
+    miningTime: number;
     hash: string;
 }
 
@@ -39,6 +41,7 @@ function getHighest(values: Array<HeightBar>): HeightBar {
         total: 0,
         blockHeight: 0,
         timestamp: 0,
+        miningTime: 0,
         hash: ''
     };
     values.forEach((values: HeightBar) => {
@@ -68,13 +71,14 @@ function HeroGraph({ yAxisTicks, blocks }: Props) {
     const { width, height } = dimensions;
 
     const blocksData: HeightBar[] = latestBlocks.map((block) => {
-        const { body, header } = block.block;
+        const { body, header, _miningTime } = block.block;
 
         const inputs = body.inputs.length;
         const outputs = body.outputs.length;
         const kernels = body.kernels.length;
         const heights = header.height;
         const timestamp = header.timestamp.seconds;
+        const miningTime = _miningTime;
         const hash = header.hash;
 
         return {
@@ -84,6 +88,7 @@ function HeroGraph({ yAxisTicks, blocks }: Props) {
             total: inputs + outputs + kernels,
             blockHeight: heights,
             timestamp: timestamp,
+            miningTime: miningTime,
             hash: hash
         };
     });
@@ -166,6 +171,7 @@ interface GraphicalElementProps {
     maxHeights: HeightBar;
     blockHeight: number;
     timestamp: number;
+    miningTime: number;
     aniClass: string;
     hash: string;
 }
@@ -182,7 +188,7 @@ function Chart({
     const { width, margin } = dimensions;
     const spaceBetweenBars = width / values.length;
     function relativeHeight(heights: HeightBar, maxHeights: HeightBar): HeightBar {
-        const { inputs, outputs, kernels, blockHeight, timestamp, hash } = heights;
+        const { inputs, outputs, kernels, blockHeight, timestamp, hash, miningTime } = heights;
         const { total: maxTotal } = maxHeights;
 
         let inputPercent = maxTotal > 0 ? inputs / maxTotal : inputs;
@@ -201,6 +207,7 @@ function Chart({
             kernels: kernelsPercent,
             blockHeight: blockHeight,
             timestamp: timestamp,
+            miningTime: miningTime,
             total: 0,
             hash: hash
         };
@@ -228,6 +235,7 @@ function Chart({
                         maxHeights={maxHeights}
                         blockHeight={heights.blockHeight}
                         timestamp={heights.timestamp}
+                        miningTime={heights.miningTime}
                         aniClass={aniClass}
                         hash={heights.hash}
                     />
@@ -245,6 +253,7 @@ function Bar({
     outputsVal,
     kernelsVal,
     blockHeight,
+    miningTime,
     timestamp,
     aniClass,
     hash
@@ -273,7 +282,7 @@ function Bar({
 
     return (
         <Link to={`/block/${hash}`} key={blockHeight} className={`overviewBars ${aniClass}`}>
-            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 35})`}>
+            <g className="tooltip total" transform={`translate(${offset - 70},${height - totalHeight - 50})`}>
                 <rect rx="3" />
                 <text x="60" y="10" xmlSpace="preserve" textAnchor="end">
                     <tspan className="timeAgo" x="60" dy="0">
@@ -290,6 +299,9 @@ function Bar({
                     </tspan>
                     <tspan className="kernels" x="60" dy="10">
                         {getTooltipText(kernelsVal, 'kernel')}
+                    </tspan>
+                    <tspan className="timeAgo" x="60" dy="10">
+                        {leftPad(fmtMSS(miningTime), 14, ' ')}
                     </tspan>
                 </text>
             </g>

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -4,4 +4,5 @@
     display: flex;
     padding: 50px 70px;
     flex-direction: column;
+    max-height: 700px;
 }

--- a/src/components/Hero.css
+++ b/src/components/Hero.css
@@ -4,5 +4,5 @@
     display: flex;
     padding: 50px 70px;
     flex-direction: column;
-    max-height: 700px;
+    /*max-height: 700px; will revisit*/
 }

--- a/src/helpers/fmtMSS.ts
+++ b/src/helpers/fmtMSS.ts
@@ -1,0 +1,3 @@
+export function fmtMSS(s) {
+    return (s - (s %= 60)) / 60 + (9 < s ? ':' : ':0') + s;
+}


### PR DESCRIPTION
## Description

- Updated Hero tooltips to have all values in one tooltip, styling.
- Tweaked Single block tooltips

#### Related issues

tari-project/block-explorer-frontend#69 but does not close as will revisit the max-height point.


#### Screenshots/Video

Hero tooltip: 
![image](https://user-images.githubusercontent.com/47271333/84913936-55053900-b0bb-11ea-907d-0cd9de1fe806.png)

Single block tooltip update: 

![image](https://user-images.githubusercontent.com/47271333/84913985-62222800-b0bb-11ea-978f-740a4aff2a45.png)

![image](https://user-images.githubusercontent.com/47271333/84914003-677f7280-b0bb-11ea-97ce-c5985278f45b.png)

