### PR TITLE
Fixed button overlapping

### DIFF
--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -44,11 +44,15 @@
     flex-direction: row;
 }
 
+.TopBar-itemContainer div:first-child {
+    margin-left: 3em;
+}
+
 .TopBar-itemContainer > * {
-    margin-left: 2em;
+    margin-right: 2em;
     display: flex;
     flex-direction: column;
-    align-items: flex-end;
+    align-items: flex-start;
     justify-content: center;
 }
 

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -45,7 +45,7 @@
 }
 
 .TopBar-itemContainer div:first-child {
-    margin-left: 3em;
+    margin-left: 2em;
 }
 
 .TopBar-itemContainer > * {

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -21,38 +21,35 @@
 .TopBar-contentContainer {
     flex: 1;
 }
-
-.TopBar-rightContainer {
-    width: calc(100% - 24em);
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-}
 .TopBar-searchContainer {
     width: calc(100% - 90px);
+    justify-content: space-between;
 }
 
-.TopBar-searchContainer,
+.TopBar-searchContainer {
+    padding: 10px 2em;
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
 .TopBar-itemContainer {
+    width: auto;
+    justify-items: flex-start;
     display: flex;
     align-items: center;
     padding: 10px 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    flex-grow: 6;
     flex-direction: row;
 }
 
 .TopBar-itemContainer > * {
-    margin-left: 1em;
+    margin-left: 2em;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
     justify-content: center;
-}
-
-.TopBar-itemContainer div:first-child {
-    margin-left: 2em;
 }
 
 .simpleBtn {
@@ -87,6 +84,7 @@
     display: none;
 }
 
-.TopBar .simpleBtn.desktop {
+.simpleBtn.desktop {
     display: flex;
+    flex-grow: 0;
 }

--- a/src/components/TopBar.css
+++ b/src/components/TopBar.css
@@ -22,6 +22,18 @@
     flex: 1;
 }
 
+.TopBar-rightContainer {
+    width: calc(100% - 24em);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+.TopBar-searchContainer {
+    width: calc(100% - 90px);
+}
+
 .TopBar-searchContainer,
 .TopBar-itemContainer {
     display: flex;
@@ -32,7 +44,7 @@
 }
 
 .TopBar-itemContainer > * {
-    margin-left: 3em;
+    margin-left: 1em;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
@@ -53,10 +65,6 @@
     height: 35px;
     width: 110px;
     border-radius: 3px;
-    position: absolute;
-    right: 5px;
-    top: 50%;
-    transform: translate(-50%, -50%);
     border: 2px solid #932fff;
     transition: background-color 0.2s ease-in, color 0.2s ease-in;
 }
@@ -73,4 +81,12 @@
     display: flex;
     font-weight: 500;
     user-select: none;
+}
+
+.TopBar .simpleBtn.mobile {
+    display: none;
+}
+
+.TopBar .simpleBtn.desktop {
+    display: flex;
 }

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -32,7 +32,7 @@ function TopBar({ metadata }: { metadata: ChainMetadata }) {
         const formattedAverageFee = numeral(metadata.averageFee).format('0,0');
         setAverageFee(formattedAverageFee);
 
-        const formattedAverageBlockTime = numeral(metadata.averageBlockTimes).format('0');
+        const formattedAverageBlockTime = numeral(metadata.averageBlockTimes).format('0') + 's';
         setAverageBlockTime(formattedAverageBlockTime);
     }, [metadata]);
 
@@ -49,19 +49,17 @@ function TopBar({ metadata }: { metadata: ChainMetadata }) {
 
             <div className="TopBar-searchContainer">
                 <TopBarSearch />
-                <div className="TopBar-rightContainer">
-                    <div className="TopBar-itemContainer">
-                        <TopBarItem label="Total Txns" value={totalTransactions} />
-                        <TopBarItem label="Avg Txns / Sec" value={averageTxPerSecond} />
-                        <TopBarItem label="Hash Rate" value={hashRate} />
-                        <TopBarItem label="Avg Fee" value={averageFee} />
-                        <TopBarItem label="Avg Block Time (Sec)" value={averageBlockTime} />
-                        <TopBarItem label="Block Height" value={blockHeight} />
-                    </div>
-                    <a href="https://tari.com" target="_blank" rel="noopener noreferrer" className="simpleBtn desktop">
-                        <p>Visit Tari.com</p>
-                    </a>
+                <div className="TopBar-itemContainer">
+                    <TopBarItem label="Total Txns" value={totalTransactions} />
+                    <TopBarItem label="Avg Txns / Sec" value={averageTxPerSecond} />
+                    <TopBarItem label="Hash Rate" value={hashRate} />
+                    <TopBarItem label="Avg Fee" value={averageFee} />
+                    <TopBarItem lowerCase={true} label="Avg Block Time" value={averageBlockTime} />
+                    <TopBarItem label="Block Height" value={blockHeight} />
                 </div>
+                <a href="https://tari.com" target="_blank" rel="noopener noreferrer" className="simpleBtn desktop">
+                    <p>Visit Tari.com</p>
+                </a>
             </div>
         </div>
     );

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -42,7 +42,7 @@ function TopBar({ metadata }: { metadata: ChainMetadata }) {
                 <Link to="/">
                     <Logo fill="#9330ff" />
                 </Link>
-                <a href="https://tari.com" target="_blank" rel="noreferrer" className="simpleBtn mobile">
+                <a href="https://tari.com" target="_blank" rel="noopener noreferrer" className="simpleBtn mobile">
                     <p>Visit Tari.com</p>
                 </a>
             </div>
@@ -58,7 +58,7 @@ function TopBar({ metadata }: { metadata: ChainMetadata }) {
                         <TopBarItem label="Avg Block Time (Sec)" value={averageBlockTime} />
                         <TopBarItem label="Block Height" value={blockHeight} />
                     </div>
-                    <a href="https://tari.com" target="_blank" rel="noreferrer" className="simpleBtn desktop">
+                    <a href="https://tari.com" target="_blank" rel="noopener noreferrer" className="simpleBtn desktop">
                         <p>Visit Tari.com</p>
                     </a>
                 </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -42,22 +42,27 @@ function TopBar({ metadata }: { metadata: ChainMetadata }) {
                 <Link to="/">
                     <Logo fill="#9330ff" />
                 </Link>
+                <a href="https://tari.com" target="_blank" rel="noreferrer" className="simpleBtn mobile">
+                    <p>Visit Tari.com</p>
+                </a>
             </div>
 
             <div className="TopBar-searchContainer">
                 <TopBarSearch />
-                <div className="TopBar-itemContainer">
-                    <TopBarItem label="Total Txns" value={totalTransactions} />
-                    <TopBarItem label="Avg Txns / Sec" value={averageTxPerSecond} />
-                    <TopBarItem label="Hash Rate" value={hashRate} />
-                    <TopBarItem label="Avg Fee" value={averageFee} />
-                    <TopBarItem label="Avg Block Time (Sec)" value={averageBlockTime} />
-                    <TopBarItem label="Block Height" value={blockHeight} />
+                <div className="TopBar-rightContainer">
+                    <div className="TopBar-itemContainer">
+                        <TopBarItem label="Total Txns" value={totalTransactions} />
+                        <TopBarItem label="Avg Txns / Sec" value={averageTxPerSecond} />
+                        <TopBarItem label="Hash Rate" value={hashRate} />
+                        <TopBarItem label="Avg Fee" value={averageFee} />
+                        <TopBarItem label="Avg Block Time (Sec)" value={averageBlockTime} />
+                        <TopBarItem label="Block Height" value={blockHeight} />
+                    </div>
+                    <a href="https://tari.com" target="_blank" rel="noreferrer" className="simpleBtn desktop">
+                        <p>Visit Tari.com</p>
+                    </a>
                 </div>
             </div>
-            <a href="https://tari.com" target="_blank" rel="noreferrer" className="simpleBtn">
-                <p>Visit Tari.com</p>
-            </a>
         </div>
     );
 }

--- a/src/components/TopBarItem.css
+++ b/src/components/TopBarItem.css
@@ -18,3 +18,7 @@
     letter-spacing: -0.21px;
     margin: 0;
 }
+
+.TopBarItem > h3.lowerCase {
+    text-transform: lowercase;
+}

--- a/src/components/TopBarItem.tsx
+++ b/src/components/TopBarItem.tsx
@@ -4,12 +4,14 @@ import './TopBarItem.css';
 interface Props {
     label: string;
     value: string;
+    lowerCase?: boolean;
 }
 
-export default function TopBarItem({ label, value }: Props) {
+export default function TopBarItem({ label, value, lowerCase }: Props) {
+    const lowerCaseClass = lowerCase ? 'lowerCase' : '';
     return (
         <div className="TopBarItem">
-            <h3>{value}</h3>
+            <h3 className={lowerCaseClass}>{value}</h3>
             <h4>{label}</h4>
         </div>
     );

--- a/src/components/TopBarSearch.css
+++ b/src/components/TopBarSearch.css
@@ -5,7 +5,7 @@
 
 .TopBar-searchBar input {
     padding: 10px 20px;
-    width: 24em;
+    width: 22em;
     border-radius: 3px;
     border: 1px solid #9330FF;
     background: #ffffff;

--- a/src/components/TopBarSearch.css
+++ b/src/components/TopBarSearch.css
@@ -1,15 +1,17 @@
 .TopBar-searchBar {
-    margin-left: 2em;
     position: relative;
+    display: flex;
+    flex-grow: 0;
 }
 
 .TopBar-searchBar input {
     padding: 10px 20px;
     width: 22em;
     border-radius: 3px;
-    border: 1px solid #9330FF;
+    border: 1px solid #9330ff;
     background: #ffffff;
 }
+
 .TopBar-searchBar input:focus {
     outline: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -24,6 +24,12 @@ body {
     .TopBar-logoContainer {
         width: 100%;
         border: none;
+        position: relative;
+    }
+    .TopBar-searchContainer,
+    .TopBar-rightContainer {
+        flex-direction: column;
+        width: 100%;
     }
     .TopBar-itemContainer {
         margin: 1em 0 0 2em;
@@ -53,10 +59,19 @@ body {
         font-size: 11px;
     }
 
-    .TopBar .simpleBtn {
-        top: 10px;
-        right: 10px;
-        transform: none;
+    .TopBar .simpleBtn.mobile {
+        display: flex;
+        position: absolute;
+        right: 1em;
+        top: 50%;
+        transform: translate(0, -50%);
+    }
+
+    .TopBar .simpleBtn.desktop {
+        display: none;
+    }
+    .TopBar-logoContainer svg {
+        align-self: center;
     }
     /*TopBar End*/
 

--- a/src/index.css
+++ b/src/index.css
@@ -26,14 +26,14 @@ body {
         border: none;
         position: relative;
     }
-    .TopBar-searchContainer,
-    .TopBar-rightContainer {
+    .TopBar-searchContainer {
         flex-direction: column;
         width: 100%;
     }
     .TopBar-itemContainer {
         margin: 1em 0 0 2em;
         padding: 0 30px;
+        flex-wrap: wrap;
     }
     .TopBar-itemContainer div:first-child,
     .TopBar-itemContainer div {
@@ -167,8 +167,15 @@ body {
 }
 
 /*Tablets*/
-@media (min-width: 992px) {
+@media (min-width: 769px) and (max-width: 1024px) {
     .App-content-mainArea {
         width: calc(100% - 100px);
+    }
+
+    .TopBar-searchBar {
+        justify-content: flex-end;
+        display: flex;
+        flex-direction: row;
+        flex-grow: 2;
     }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -171,9 +171,11 @@ body {
 /*Tablets*/
 @media (min-width: 992px) and (max-width: 1024px) {
     .TopBar-searchBar {
-        justify-content: flex-end;
         display: flex;
         flex-direction: row;
-        flex-grow: 2;
+    }
+
+    .TopBar-itemContainer div:first-child {
+        margin-left: 0;
     }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -22,13 +22,15 @@ body {
         flex-direction: column;
     }
     .TopBar-logoContainer {
-        width: 100%;
+        width: 100vw;
         border: none;
         position: relative;
     }
     .TopBar-searchContainer {
         flex-direction: column;
-        width: 100%;
+        width: 100vw;
+        padding: 0;
+        margin: 0 0 1em 0;
     }
     .TopBar-itemContainer {
         margin: 1em 0 0 2em;
@@ -167,11 +169,7 @@ body {
 }
 
 /*Tablets*/
-@media (min-width: 769px) and (max-width: 1024px) {
-    .App-content-mainArea {
-        width: calc(100% - 100px);
-    }
-
+@media (min-width: 992px) and (max-width: 1024px) {
     .TopBar-searchBar {
         justify-content: flex-end;
         display: flex;


### PR DESCRIPTION
## Description

- Visit Tari button was overlapping content on smaller screens
- Also left aligned the sub-headers



#### Notes
- Closes tari-project/block-explorer-frontend#98
#### Screenshots

- Desktop (larger screens):
![image](https://user-images.githubusercontent.com/47271333/85386929-7dba8200-b544-11ea-9454-c3a6897857ca.png)


- Desktop (around Mac 13"): 
![image](https://user-images.githubusercontent.com/47271333/85387038-a04c9b00-b544-11ea-8d5c-7617db980246.png)


- Tablet: 
Lanscape: 
![image](https://user-images.githubusercontent.com/47271333/85387069-aa6e9980-b544-11ea-80b5-7c03c1f6b9ea.png)


- Mobile:
![image](https://user-images.githubusercontent.com/47271333/85286905-c49c6f00-b493-11ea-9cba-611eee9a9e57.png)


