### PR TITLE
[DNM] Hero Graph remove old block for new block

### DIFF
--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -70,6 +70,9 @@ function HeroGraph({ yAxisTicks, blocks }: Props) {
 
     const { width, height } = dimensions;
 
+    //Remove last block
+    latestBlocks.splice(-1,1);
+
     const blocksData: HeightBar[] = latestBlocks.map((block) => {
         const { body, header, _miningTime } = block.block;
 

--- a/src/components/Graphs/HeroGraph.tsx
+++ b/src/components/Graphs/HeroGraph.tsx
@@ -70,9 +70,6 @@ function HeroGraph({ yAxisTicks, blocks }: Props) {
 
     const { width, height } = dimensions;
 
-    //Remove last block
-    latestBlocks.splice(-1,1);
-
     const blocksData: HeightBar[] = latestBlocks.map((block) => {
         const { body, header, _miningTime } = block.block;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ const config = {
         process.env.REACT_APP_EXPLORER_API_DOMAIN + '/ws'
     ),
     tokenName: process.env.REACT_APP_TOKEN_NAME || 'tXTR',
-    initialBlockCount: +(process.env.REACT_APP_INITIAL_BLOCK_COUNT || 100)
+    initialBlockCount: +(process.env.REACT_APP_INITIAL_BLOCK_COUNT || 100),
+    maxBlocks: +(process.env.REACT_APP_MAX_BLOCKS || 100)
 };
 export default config;

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -25,6 +25,11 @@ export async function fetchBlocksData(limit = 30, sort = 'desc', page = 0): Prom
     if (sort === 'desc') {
         blocks.blocks.sort((a, b) => b.block.header.height - a.block.header.height);
     }
+
+    if(blocks.blocks.length > config.maxBlocks) {
+        blocks.blocks.splice(-1,1);
+    }
+
     return blocks;
 }
 


### PR DESCRIPTION
### Description
When the explorer is opened, new blocks will keep rolling in and the graph becomes unreadable.
### Screencast
https://share.getcloudapp.com/E0uzYYjj

Closes: tari-project/block-explorer-frontend#70