### PR TITLE
Fix ESlint warning

### DIFF
--- a/src/components/Graphs/ClusterGraph.tsx
+++ b/src/components/Graphs/ClusterGraph.tsx
@@ -69,7 +69,10 @@ function forceCollide(nodes) {
                                 l = Math.hypot(x, y);
                             if (l < r) {
                                 l = ((l - r) / l) * alpha;
-                                return (d.x -= x *= l), (d.y -= y *= l), (q.data.x += x), (q.data.y += y);
+                                d.x -= x *= l;
+                                d.y -= y *= l;
+                                q.data.x += x;
+                                q.data.y += y;
                             }
                         }
                     } while ((q = q.next));


### PR DESCRIPTION
ESLint was reporting the following warning:

```
./src/components/Graphs/ClusterGraph.tsx
  Line 72:55:  Unexpected use of comma operator  no-sequences
```

The return statement in the collision sim was performing computation solely for side effects, discarding the return value. This change doesn't affect the behavior of the sim.