### PR TITLE
Evenly space bottom graphs on wider screens

### DIFF
--- a/src/components/BlockExplorer.css
+++ b/src/components/BlockExplorer.css
@@ -4,3 +4,9 @@
     width: 100%;
     flex-wrap: wrap;
 }
+
+@media (min-width: 1451px) {
+    .twoCol {
+        justify-content: space-evenly;
+    }
+}


### PR DESCRIPTION
I determined the breakpoint manually.

|Before|After|
|---|---|
|<img width="2672" alt="before" src="https://user-images.githubusercontent.com/10366797/90988098-6f163880-e590-11ea-8df9-fd4c8fedcee3.png">|<img width="2672" alt="after" src="https://user-images.githubusercontent.com/10366797/90988096-6aea1b00-e590-11ea-8cdd-3a8d563d8006.png">|