### PR TITLE
Add search kernel functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { setupWebsockets } from './helpers/api';
 import store from './store';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import SingleBlock from './components/SingleBlock';
+import SearchKernel from './components/SearchKernel';
 
 export default function App() {
     useEffect(() => {
@@ -26,6 +27,7 @@ export default function App() {
                         <Switch>
                             <Route exact path="/" component={BlockExplorer} />
                             <Route path="/block/:id" component={SingleBlock} />
+                            <Route path="/kernel/:nonce/:signature" component={SearchKernel} />
                         </Switch>
                     </div>
                 </div>

--- a/src/components/SearchKernel.css
+++ b/src/components/SearchKernel.css
@@ -1,0 +1,20 @@
+.SearchKernel {
+    padding: 2em;
+    min-height: 800px;
+}
+
+.SearchKernel h1 {
+    font-weight: bold;
+    font-family: Avenir, sans-serif;
+    font-size: 30px;
+}
+
+.SearchKernel h2 {
+    font-weight: bold;
+    font-family: Avenir, sans-serif;
+    font-size: 20px;
+}
+
+.SearchKernel a {
+    text-decoration: none;
+}

--- a/src/components/SearchKernel.tsx
+++ b/src/components/SearchKernel.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import React, { useEffect, useState } from 'react';
+import './SearchKernel.css';
+import { useParams, Link, Redirect } from 'react-router-dom';
+import { searchKernel } from '../helpers/api';
+import { ReactComponent as LoadingBars } from '../assets/bars.svg';
+
+interface Status {
+    status: string;
+    message: string;
+    hash?: string;
+}
+
+const renderStatus = (status: Status) => {
+    switch (status.status) {
+        case 'redirect':
+            return <Redirect push to={`/block/${status.hash}`} />;
+        case 'complete':
+            return (
+                <div>
+                    <LoadingBars fill={'#000'} />
+                    <h1>{status.message}</h1>
+                    <h2>Redirecting...</h2>
+                </div>
+            );
+        case 'loading':
+            return (
+                <div>
+                    <LoadingBars fill={'#000'} />
+                    <h1>{status.message}</h1>
+                </div>
+            );
+        default:
+            return (
+                <h1 className="noBlockFound">
+                    {status.message} <Link to={'/'}>Go Back</Link>
+                </h1>
+            );
+    }
+};
+
+const SearchKernel = () => {
+    const { nonce, signature } = useParams();
+    const [status, setStatus] = useState({ status: 'loading', message: '', hash: '' } as Status);
+    useEffect(() => {
+        let timer;
+
+        if (!nonce || !signature) {
+            setStatus({
+                status: 'error',
+                message: 'Invalid nonce or signature'
+            });
+            return;
+        }
+        setStatus({
+            status: 'loading',
+            message: 'Searching for transaction...'
+        });
+        searchKernel(nonce, signature)
+            .then((response) => {
+                if (response.blocks.length > 0) {
+                    const block = response.blocks[0];
+                    const height = block.block.header.height;
+                    const hash = block.block.header.hash;
+                    const message = `Found in block #${height}.`;
+                    setStatus({
+                        status: 'complete',
+                        message,
+                        hash
+                    });
+                    timer = setTimeout(() => setStatus({ status: 'redirect', message, hash }), 2000);
+                } else {
+                    setStatus({
+                        status: 'error',
+                        message: 'There was an error finding that transaction.'
+                    });
+                }
+            })
+            .catch((e) => {
+                console.error(e);
+                setStatus({
+                    status: 'error',
+                    message: 'Transaction not found'
+                });
+            });
+        if (timer) return window.clearTimeout(timer);
+    }, [nonce, signature]);
+
+    return <div className="SearchKernel">{renderStatus(status)}</div>;
+};
+
+export default SearchKernel;

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -89,6 +89,15 @@ export async function fetchSingleBlock(blockId: string | number): Promise<Blocks
     }
 }
 
+export async function searchKernel(publicNonce: string, signature: string): Promise<Blocks> {
+    try {
+        const response = await fetch(`${apiUrl}/kernel/${publicNonce}/${signature}`);
+        return await response.json();
+    } catch (e) {
+        return e;
+    }
+}
+
 export interface Constants {
     coinbase_lock_height: number;
     blockchain_version: number;


### PR DESCRIPTION
This PR requires tari-project/blockchain-explorer-api#45 

Resolves #107 

This commit adds the ability to search for a transaction by providing the public nonce and signature to the `kernel` endpoint. If the transaction is found, the user will be redirected to that block. 

You can test using these values, to find block 2427 

```
/kernel/8e022e81990ffc3361f8646819e683a3bc27a822c7a6b9fbbf86c76675418337/1f88e5489c00391403326e6e4c072db9bb59f5ff34dd30e850098615ad265c01
```

demo here https://gfycat.com/nextblushingglobefish