### PR TITLE
Maintenance

### DIFF
--- a/src/components/EstimatedHashGraph.tsx
+++ b/src/components/EstimatedHashGraph.tsx
@@ -8,12 +8,15 @@ interface Props {
 
 function EstimatedHashGraph({ difficulties }: Props) {
     const difficultyArray: any[] = [];
-    difficulties.forEach((item) => {
+    difficulties.forEach( function(item, index, array) {
+        // exclude latest block since estimated hash rate will be zero
+        if (index !== 0){
         const { estimated_hash_rate: estimatedHashRate, height } = item;
         difficultyArray.push({ y: estimatedHashRate, x: +height });
+        }
     });
 
-    const yAxisLabel = 'difficulty';
+    const yAxisLabel = 'estimated hash rate';
     const xAxisLabel = 'block height';
 
     return (

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -89,10 +89,10 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
     }
 
     return (
-        <div className="graphWrapper networkDifficultyGraph">
+        <div className="graphWrapper networkHashrateGraph">
             <PlainGraphTitle
-                title="Network Difficulty"
-                subTitle={`How difficult it is to mine a new block for the Tari blockchain.`}
+                title="Historical Hash Rate"
+                subTitle={`The estimated hashrate for the network per block.`}
             />
             <svg
                 viewBox={`0 0 ${width} ${height}`}

--- a/src/components/SingleBlock.tsx
+++ b/src/components/SingleBlock.tsx
@@ -21,6 +21,19 @@ interface Status {
     message: string;
 }
 
+function BlockType(param) {
+    switch(param) {
+        case '0':
+          return "Monero"
+        case '1':
+          return "Blake"
+        case '2':
+          return "Sha3"
+        default:
+          return "Undefined"
+      }
+  }
+
 function SingleBlock({ constants }: Props) {
     const { id } = useParams();
     const [singleBlock, setSingleBlock] = useState({} as Block);
@@ -102,7 +115,7 @@ function SingleBlock({ constants }: Props) {
     }, [constants]);
 
     const { hash, prev_hash, nonce, total_kernel_offset, version, timestamp, height } = blockHeader;
-    const { accumulated_monero_difficulty, accumulated_blake_difficulty } = blockPow;
+    const { pow_algo } = blockPow;
 
     const date = timestamp && new Date(timestamp.seconds * 1000).toLocaleString();
     const { _weight } = singleBlock;
@@ -119,8 +132,7 @@ function SingleBlock({ constants }: Props) {
                     <StatRow label="Timestamp" value={date} />
                     <h1>Technical Details</h1>
                     <StatRow label="Block Height" value={height} />
-                    <StatRow label="Accumulated Monero Difficulty" value={accumulated_monero_difficulty} />
-                    <StatRow label="Accumulated Blake Difficulty" value={accumulated_blake_difficulty} />
+                    <StatRow label="Block Algorithm" value={BlockType(pow_algo)} />
                     <Link to={`/block/${prev_hash}`}>
                         <StatRow label="Previous Hash" value={prev_hash} />
                     </Link>

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -69,8 +69,11 @@ export function setupWebsockets(store) {
 }
 
 export interface NetworkDifficultyEstimatedHash {
+    difficulty: number;
     estimated_hash_rate: number;
     height: number;
+    timestamp: number;
+    pow_algo: number;
 }
 
 export type NetworkDifficultyEstimatedHashes = Array<NetworkDifficultyEstimatedHash>;

--- a/src/types/Blocks.d.ts
+++ b/src/types/Blocks.d.ts
@@ -33,8 +33,6 @@ export interface Timestamp {
 }
 export interface Pow {
     pow_algo: string;
-    accumulated_monero_difficulty: string;
-    accumulated_blake_difficulty: string;
     pow_data: string;
 }
 export interface Body {


### PR DESCRIPTION
This PR removes redundant fields from the block explorer and aligns the interfaces to the grpc methods.

It also updates the title and axis labels for the EstimatedHashGraph which were incorrect according to the fields being displayed.

Linked to PR: https://github.com/tari-project/blockchain-explorer-api/pull/51