### PR TITLE
Network difficulty graph

### DIFF
--- a/src/components/BlockExplorer.tsx
+++ b/src/components/BlockExplorer.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import './BlockExplorer.css';
 import PlainGraphTitle from './GraphTitles/PlainGraphTitle';
 import EstimatedHashGraph from './EstimatedHashGraph';
+import TargetDifficultyGraph from './TargetDifficultyGraph';
 import Hero from './Hero';
 import HeroGraph from './Graphs/HeroGraph';
 import LatestBlocks from './LatestBlocks';
@@ -22,6 +23,9 @@ export default function BlockExplorer() {
             <div className="twoCol">
                 <EstimatedHashGraph />
                 <CirculatingTokenGraph />
+            </div>
+            <div className="twoCol">
+                <TargetDifficultyGraph />
             </div>
         </div>
     );

--- a/src/components/EstimatedHashGraph.tsx
+++ b/src/components/EstimatedHashGraph.tsx
@@ -8,12 +8,15 @@ interface Props {
 
 function EstimatedHashGraph({ difficulties }: Props) {
     const difficultyArray: any[] = [];
-    difficulties.forEach((item) => {
+    difficulties.forEach( function(item, index, array) {
+        // exclude latest block since estimated hash rate will be zero
+        if (index !== 0){
         const { estimated_hash_rate: estimatedHashRate, height } = item;
         difficultyArray.push({ y: estimatedHashRate, x: +height });
+        }
     });
 
-    const yAxisLabel = 'difficulty';
+    const yAxisLabel = 'estimated hash rate';
     const xAxisLabel = 'block height';
 
     return (

--- a/src/components/Graphs/MultiLinePlot.tsx
+++ b/src/components/Graphs/MultiLinePlot.tsx
@@ -1,0 +1,179 @@
+import * as d3 from 'd3';
+import React from 'react';
+import './PolygonGraph.css';
+import PlainGraphTitle from '../GraphTitles/PlainGraphTitle';
+import numeral from 'numeral';
+
+interface Props {
+    data: any[];
+    width: number;
+    height: number;
+    yAxisTicks: number;
+    yAxisLabel: string;
+    xAxisLabel: string;
+}
+
+export default function MultiLinePlot({ width, height, yAxisTicks, data, xAxisLabel, yAxisLabel }: Props) {
+    const YHighestNum = Math.max(...data.map((o) => o.y));
+    const XHighestNumber = Math.max(...data.map((o) => o.x));
+    const XLowestNumber = Math.min(...data.map((o) => o.x));
+    const xScale = d3.scaleLinear().domain([XHighestNumber, XLowestNumber]).range([0, width]);
+    const yScale = d3.scaleLinear().domain([0, YHighestNum]).range([height, 0]);
+
+    //Todo: Data needs to be padded (last known value per algo copied where there are gaps) to prevent only line segments being rendered.
+
+    var Sha3Difficulties = data.filter(function(item) {
+        return item.group === "2";
+    });
+    var MoneroDifficulties = data.filter(function(item) {
+        return item.group === "0";
+    });
+
+    ///console.log(MoneroDifficulties);
+    ///console.log("...");
+    ///console.log(Sha3Difficulties);
+
+    const transformedMoneroData = MoneroDifficulties.map((d, i) => {
+        return {
+            x: xScale(d.x),
+            y: yScale(d.y),
+            blockHeight: d.x
+        };
+    });
+
+    const transformedSha3Data = Sha3Difficulties.map((d, i) => {
+        return {
+            x: xScale(d.x),
+            y: yScale(d.y),
+            blockHeight: d.x
+        };
+    });
+
+    const xMoneroAccessor = (transformedMoneroData: any) => transformedMoneroData.x;
+    const yMoneroAccessor = (transformedMoneroData: any) => transformedMoneroData.y;
+    const xSha3Accessor = (transformedSha3Data: any) => transformedSha3Data.x;
+    const ySha3Accessor = (transformedSha3Data: any) => transformedSha3Data.y;
+
+    const lineGeneratorSha3: any = d3.line().x(xSha3Accessor).y(ySha3Accessor);
+    const lineGeneratorMonero: any = d3.line().x(xMoneroAccessor).y(yMoneroAccessor);
+
+    function round5({ num }: { num: any }) {
+        return Math.ceil(num / 5) * 5;
+    }
+
+    function renderYAxis() {
+        const nums: Array<any> = [];
+        let ticks = yAxisTicks + 1;
+
+        for (let i = 0; i < yAxisTicks + 1; i++) {
+            ticks--;
+
+            const num = YHighestNum === Number.NEGATIVE_INFINITY ? 0 : (YHighestNum / yAxisTicks) * ticks;
+            const displayNum = round5({ num });
+            nums.push(
+                <g key={i}>
+                    <text
+                        style={{ fontFamily: 'Avenir, sans-serif', fontSize: 14, display: 'block' }}
+                        key={`${i}-text`}
+                        fill="#adadad"
+                        x={-30}
+                        y={(height / yAxisTicks) * i}
+                    >
+                        {numeral(displayNum).format('0a')}
+                    </text>
+
+                    <line
+                        key={`${i}-line`}
+                        width={width}
+                        stroke="#adadad"
+                        strokeDasharray="3.3"
+                        strokeWidth={1}
+                        x1={0}
+                        x2={width}
+                        y1={(height / yAxisTicks) * i}
+                        y2={(height / yAxisTicks) * i}
+                    />
+                </g>
+            );
+        }
+        return nums;
+    }
+
+    function renderXAxis() {
+        const nums: Array<any> = [];
+        for (let i = 0; i < data.length; i += 10) {
+            nums.push(
+                <div key={i} className="tick">
+                    {data[i].x}
+                </div>
+            );
+        }
+        return nums;
+    }
+
+    return (
+        <div className="graphWrapper networkHashrateGraph">
+            <PlainGraphTitle
+                title="Network Difficulty"
+                subTitle={`How hard it is to mine a block on the network.`}
+            />
+            <svg
+                viewBox={`0 0 ${width} ${height}`}
+                preserveAspectRatio="xMidYMid meet"
+                className="networkDifficultyPaths"
+                height={height}
+                width={width}
+            >
+                <g className="yAxisLabel">
+                    <text style={{ fontFamily: 'Avenir, sans-serif', fontSize: 11 }} fill="#bababa" x={-120} y={-40}>
+                        {yAxisLabel}
+                    </text>
+                </g>
+                {renderYAxis()}
+                <path style={{ fill: 'none', stroke: '#ff6600', strokeWidth: 2 }} d={lineGeneratorMonero(transformedMoneroData)} />
+                {transformedMoneroData.map((item, i) => {
+                    return (
+                        <g key={i} className="shapeHolder">
+                            <circle cx={item.x} cy={item.y} r="15" fill="#352583" fillOpacity="0" />
+                            <g className="tooltip" opacity="0.9">
+                                <rect rx={3} x={item.x - 20} y={item.y - 20} width="25" />
+                                <text x={item.x - 16} y={item.y - 7}>
+                                    {numeral(data[i].y || 0).format('0a')}
+                                </text>
+                            </g>
+                            <g className="tooltip blockHeightTooltip" opacity="0.9">
+                                <rect rx={3} x={item.x - 35} y={item.y - 45} width="40" />
+                                <text x={item.x - 31} y={item.y - 32}>
+                                    {item.blockHeight}
+                                </text>
+                            </g>
+                        </g>
+                    );
+                })}
+                
+                <path style={{ fill: 'none', stroke: '#352583', strokeWidth: 2 }} d={lineGeneratorSha3(transformedSha3Data)} />
+                {transformedSha3Data.map((item, i) => {
+                    return (
+                        <g key={i} className="shapeHolder">
+                            <circle cx={item.x} cy={item.y} r="15" fill="#352583" fillOpacity="0" />
+                            <g className="tooltip" opacity="0.9">
+                                <rect rx={3} x={item.x - 20} y={item.y - 20} width="25" />
+                                <text x={item.x - 16} y={item.y - 7}>
+                                    {numeral(data[i].y || 0).format('0a')}
+                                </text>
+                            </g>
+                            <g className="tooltip blockHeightTooltip" opacity="0.9">
+                                <rect rx={3} x={item.x - 35} y={item.y - 45} width="40" />
+                                <text x={item.x - 31} y={item.y - 32}>
+                                    {item.blockHeight}
+                                </text>
+                            </g>
+                        </g>
+                    );
+                })}
+            </svg>
+            <div className="xAxisDate">{renderXAxis()}</div>
+            <div className="xAxisLabel">{xAxisLabel}</div>
+        </div>
+    );
+}

--- a/src/components/Graphs/PolygonGraph.css
+++ b/src/components/Graphs/PolygonGraph.css
@@ -31,7 +31,7 @@
     width: 100% !important;
 }
 
-.networkDifficultyGraph {
+.networkHashrateGraph {
     margin: 30px;
 }
 

--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -89,10 +89,10 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
     }
 
     return (
-        <div className="graphWrapper networkDifficultyGraph">
+        <div className="graphWrapper networkHashrateGraph">
             <PlainGraphTitle
-                title="Network Difficulty"
-                subTitle={`How difficult it is to mine a new block for the Tari blockchain.`}
+                title="Historical Hash Rate"
+                subTitle={`The estimated hashrate for the network per block.`}
             />
             <svg
                 viewBox={`0 0 ${width} ${height}`}

--- a/src/components/SingleBlock.tsx
+++ b/src/components/SingleBlock.tsx
@@ -21,6 +21,19 @@ interface Status {
     message: string;
 }
 
+function BlockType(param) {
+    switch(param) {
+        case '0':
+          return "Monero"
+        case '1':
+          return "Blake"
+        case '2':
+          return "Sha3"
+        default:
+          return "Undefined"
+      }
+  }
+
 function SingleBlock({ constants }: Props) {
     const { id } = useParams();
     const [singleBlock, setSingleBlock] = useState({} as Block);
@@ -102,7 +115,7 @@ function SingleBlock({ constants }: Props) {
     }, [constants]);
 
     const { hash, prev_hash, nonce, total_kernel_offset, version, timestamp, height } = blockHeader;
-    const { accumulated_monero_difficulty, accumulated_blake_difficulty } = blockPow;
+    const { pow_algo } = blockPow;
 
     const date = timestamp && new Date(timestamp.seconds * 1000).toLocaleString();
     const { _weight } = singleBlock;
@@ -119,8 +132,7 @@ function SingleBlock({ constants }: Props) {
                     <StatRow label="Timestamp" value={date} />
                     <h1>Technical Details</h1>
                     <StatRow label="Block Height" value={height} />
-                    <StatRow label="Accumulated Monero Difficulty" value={accumulated_monero_difficulty} />
-                    <StatRow label="Accumulated Blake Difficulty" value={accumulated_blake_difficulty} />
+                    <StatRow label="Block Algorithm" value={BlockType(pow_algo)} />
                     <Link to={`/block/${prev_hash}`}>
                         <StatRow label="Previous Hash" value={prev_hash} />
                     </Link>

--- a/src/components/TargetDifficultyGraph.tsx
+++ b/src/components/TargetDifficultyGraph.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import MultiLinePlot from './Graphs/MultiLinePlot';
+import { NetworkDifficultyEstimatedHashes } from '../helpers/api';
+import { connect } from 'react-redux';
+interface Props {
+    difficulties: NetworkDifficultyEstimatedHashes;
+}
+
+function TargetDifficultyGraph({ difficulties }: Props) {
+    const difficultyArray: any[] = [];
+    difficulties.forEach( function(item) {
+        const { difficulty, height, pow_algo } = item;
+        difficultyArray.push({ y: difficulty, x: +height, group: pow_algo});
+    });
+    console.log(difficultyArray);
+    const yAxisLabel = 'target difficulty';
+    const xAxisLabel = 'block height';
+
+    return (
+        <MultiLinePlot
+            data={difficultyArray as any[]}
+            width={500}
+            height={220}
+            yAxisTicks={6}
+            yAxisLabel={yAxisLabel}
+            xAxisLabel={xAxisLabel}
+        />
+    );
+}
+
+const mapStateToProps = (state) => ({
+    difficulties: state.difficulties
+});
+export default connect(mapStateToProps)(TargetDifficultyGraph);

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -69,8 +69,11 @@ export function setupWebsockets(store) {
 }
 
 export interface NetworkDifficultyEstimatedHash {
+    difficulty: number;
     estimated_hash_rate: number;
     height: number;
+    timestamp: number;
+    pow_algo: number;
 }
 
 export type NetworkDifficultyEstimatedHashes = Array<NetworkDifficultyEstimatedHash>;

--- a/src/index.css
+++ b/src/index.css
@@ -124,12 +124,12 @@ body {
         padding: 0;
     }
 
-    .networkDifficultyGraph .xAxisDate {
+    .networkHashrateGraph .xAxisDate {
         width: auto;
         margin: 0 0 0 30px;
     }
 
-    .networkDifficultyGraph .xAxisDate .tick {
+    .networkHashrateGraph .xAxisDate .tick {
         font-size: 11px;
     }
 

--- a/src/types/Blocks.d.ts
+++ b/src/types/Blocks.d.ts
@@ -33,8 +33,6 @@ export interface Timestamp {
 }
 export interface Pow {
     pow_algo: string;
-    accumulated_monero_difficulty: string;
-    accumulated_blake_difficulty: string;
     pow_data: string;
 }
 export interface Body {


### PR DESCRIPTION
This PR implements the network difficulty graph into the block explorer again.

Illustrates the code needed to display the target difficulty per mining algorithm.

Basics are there but does need to be refactored  and cleaned up.

Linked to https://github.com/tari-project/block-explorer-frontend/pull/112

<img width="668" alt="Screen Shot 2021-02-05 at 1 03 36 AM" src="https://user-images.githubusercontent.com/51991544/107001615-9bb2bb00-6792-11eb-8706-2e6763910290.png">
