### PR TITLE
Update historical hash rate chart

### DIFF
--- a/src/components/Graphs/PolygonGraph.tsx
+++ b/src/components/Graphs/PolygonGraph.tsx
@@ -17,7 +17,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
     const YHighestNum = Math.max(...data.map((o) => o.y));
     const XHighestNumber = Math.max(...data.map((o) => o.x));
     const XLowestNumber = Math.min(...data.map((o) => o.x));
-    const xScale = d3.scaleLinear().domain([XHighestNumber, XLowestNumber]).range([0, width]);
+    const xScale = d3.scaleLinear().domain([XLowestNumber, XHighestNumber]).range([0, width]);
     const yScale = d3.scaleLinear().domain([0, YHighestNum]).range([height, 0]);
     const transformedData = data.map((d, i) => {
         return {
@@ -78,7 +78,7 @@ export default function PolygonGraph({ width, height, yAxisTicks, data, xAxisLab
 
     function renderXAxis() {
         const nums: Array<any> = [];
-        for (let i = 0; i < data.length; i += 10) {
+        for (let i = data.length - 1; i >= 0; i -= 4) {
             nums.push(
                 <div key={i} className="tick">
                     {data[i].x}


### PR DESCRIPTION
This addresses the Issue https://github.com/tari-project/block-explorer-frontend/issues/118

# Changes

- Reversed the graph such that newest block is on the right.
- Also changed the intervals from 10 to 4 since that aligned well with the data labels on the graphs.


<img width="744" alt="Screen Shot 2021-03-01 at 3 07 45 PM" src="https://user-images.githubusercontent.com/34412458/109571037-e4167d80-7a9f-11eb-9d4d-8b511908ea4a.png">

---

Note: There are about 30 linting issues that were discovered when I ran `npm run lint` in multiple files. I checked that none of them were related to my changes. Separate PR can be created to tackle those issues.
