### PR TITLE
Display block not found message

### DIFF
--- a/src/components/SingleBlock.tsx
+++ b/src/components/SingleBlock.tsx
@@ -55,57 +55,59 @@ function SingleBlock({ constants }: Props) {
         });
         fetchSingleBlock(id)
             .then((block) => {
-                if (block && block.block) {
-                    setSingleBlock(block.block);
-                    setblockHeader(block.block.header as Header);
-                    setblockPow(block.block.header.pow as Pow);
-                    const blockBody = block.block.body as Body;
-                    const { inputs = [], kernels = [], outputs = [] } = blockBody;
-                    let singleBlockDataArray: ClusterPoint[] = [];
-                    singleBlockDataArray = singleBlockDataArray.concat(
-                        inputs.map((i) => ({
-                            group: 'inputs',
-                            size: inputs.length,
-                            color: '#F97C0C',
-                            tooltip: `Input<br/>${i.commitment.slice(0, 10)}`
-                        }))
-                    );
-
-                    singleBlockDataArray = singleBlockDataArray.concat(
-                        kernels.map((i) => ({
-                            group: 'kernels',
-                            size: kernels.length,
-                            color: '#FB576D',
-                            tooltip: `Kernel<br/>${i.excess.slice(0, 10)}`
-                        }))
-                    );
-
-                    singleBlockDataArray = singleBlockDataArray.concat(
-                        outputs.map((i) => ({
-                            group: 'outputs',
-                            size: outputs.length,
-                            color: '#2274AF',
-                            tooltip: `Output<br/>${i.commitment.slice(0, 10)}`
-                        }))
-                    );
-                    setClusterData(singleBlockDataArray);
-                    setStatus({
-                        status: 'complete',
-                        message: ''
-                    });
-                } else {
+                if (!block || !block.block) {
                     setStatus({
                         status: 'error',
-                        message: 'There was an error fetching the block'
+                        message: 'Block not found'
                     });
+                    return;
                 }
+
+                setSingleBlock(block.block);
+                setblockHeader(block.block.header as Header);
+                setblockPow(block.block.header.pow as Pow);
+                const blockBody = block.block.body as Body;
+                const { inputs = [], kernels = [], outputs = [] } = blockBody;
+                let singleBlockDataArray: ClusterPoint[] = [];
+                singleBlockDataArray = singleBlockDataArray.concat(
+                    inputs.map((i) => ({
+                        group: 'inputs',
+                        size: inputs.length,
+                        color: '#F97C0C',
+                        tooltip: `Input<br/>${i.commitment.slice(0, 10)}`
+                    }))
+                );
+
+                singleBlockDataArray = singleBlockDataArray.concat(
+                    kernels.map((i) => ({
+                        group: 'kernels',
+                        size: kernels.length,
+                        color: '#FB576D',
+                        tooltip: `Kernel<br/>${i.excess.slice(0, 10)}`
+                    }))
+                );
+
+                singleBlockDataArray = singleBlockDataArray.concat(
+                    outputs.map((i) => ({
+                        group: 'outputs',
+                        size: outputs.length,
+                        color: '#2274AF',
+                        tooltip: `Output<br/>${i.commitment.slice(0, 10)}`
+                    }))
+                );
+                setClusterData(singleBlockDataArray);
+                setStatus({
+                    status: 'complete',
+                    message: ''
+                });
             })
             .catch((e) => {
                 console.error(e);
                 setStatus({
                     status: 'error',
-                    message: 'Block not found'
+                    message: e.error?.message || 'There was an error fetching the block'
                 });
+
             });
     }, [id]);
 
@@ -147,7 +149,7 @@ function SingleBlock({ constants }: Props) {
                 <LoadingBars className="fill-color-lowlight" />
             ) : (
                 <h1 className="noBlockFound">
-                    {status.message} <Link to={'/'}>Go Back</Link>
+                    {status.message}<br /><br /><Link to={'/'}>Go Back</Link>
                 </h1>
             )}
         </div>

--- a/src/helpers/api.ts
+++ b/src/helpers/api.ts
@@ -14,14 +14,21 @@ export interface ChainMetadata {
     averageTxPerSecond: number;
 }
 
+async function fetchApi<T>(uri: String): Promise<T> {
+    const response = await fetch(`${apiUrl}${uri}`);
+    const json = await response.json();
+    if (!response.ok) {
+        throw json;
+    }
+    return json;
+}
+
 export async function fetchChainMetadata(): Promise<ChainMetadata> {
-    const response = await fetch(`${apiUrl}/chain-metadata`);
-    return await response.json();
+    return await fetchApi(`/chain-metadata`);
 }
 
 export async function fetchBlocksData(limit = 30, sort = 'desc', page = 0): Promise<Blocks> {
-    const response = await fetch(`${apiUrl}/blocks?limit=${limit}&sort=${sort}&page=${page}`);
-    const blocks = await response.json();
+    let blocks = await fetchApi<Blocks>(`/blocks?limit=${limit}&sort=${sort}&page=${page}`);
     if (sort === 'desc') {
         blocks.blocks.sort((a, b) => b.block.header.height - a.block.header.height);
     }
@@ -36,9 +43,7 @@ interface TokensInCirculation {
 }
 
 export async function fetchTokensInCirculation(fromTip = 20160, step = 360): Promise<TokensInCirculation> {
-    const response = await fetch(`${apiUrl}/tokens-in-circulation?from_tip=${fromTip}&step=${step}`);
-    const tokens = await response.json();
-    return tokens;
+    return await fetchApi(`/tokens-in-circulation?from_tip=${fromTip}&step=${step}`);
 }
 
 export function setupWebsockets(store) {
@@ -79,26 +84,15 @@ export interface NetworkDifficultyEstimatedHash {
 export type NetworkDifficultyEstimatedHashes = Array<NetworkDifficultyEstimatedHash>;
 
 export async function fetchNetworkDifficulty(): Promise<NetworkDifficultyEstimatedHashes> {
-    const response = await fetch(`${apiUrl}/network-difficulty`);
-    return await response.json();
+    return await fetchApi(`/network-difficulty`);
 }
 
 export async function fetchSingleBlock(blockId: string | number): Promise<BlocksEntity> {
-    try {
-        const response = await fetch(`${apiUrl}/blocks/${blockId}`);
-        return await response.json();
-    } catch (e) {
-        return e;
-    }
+    return await fetchApi(`/blocks/${blockId}`);
 }
 
 export async function searchKernel(publicNonce: string, signature: string): Promise<Blocks> {
-    try {
-        const response = await fetch(`${apiUrl}/kernel/${publicNonce}/${signature}`);
-        return await response.json();
-    } catch (e) {
-        return e;
-    }
+    return await fetchApi(`/kernel/${publicNonce}/${signature}`);
 }
 
 export interface Constants {
@@ -121,6 +115,5 @@ export interface Constants {
 }
 
 export async function fetchConstantsData(): Promise<Constants> {
-    const response = await fetch(`${apiUrl}/constants`);
-    return await response.json();
+    return await fetchApi(`/constants`);
 }


### PR DESCRIPTION
- Display block not found error message when the block cannot be found
  Requires https://github.com/tari-project/blockchain-explorer-api/pull/52
  however frontend will not break using previous API
- Made http error response handling more consistent

**Before:**
![image](https://user-images.githubusercontent.com/1057902/111988997-e0639d00-8b19-11eb-9c9e-97aa61396718.png)

**After**

![image](https://user-images.githubusercontent.com/1057902/111989850-fc1b7300-8b1a-11eb-94b0-08e93c4c8787.png)



(If the 'Go Back' link should be on the same line as the message let me know and I'll change it back - I'm not a designer ;)) 