### PR TITLE
fix: Graph alignment on homepage

### DIFF
--- a/src/components/BlockExplorer.tsx
+++ b/src/components/BlockExplorer.tsx
@@ -18,7 +18,7 @@ export default function BlockExplorer() {
                 <LatestBlocks />
             </Hero>
 
-            <article className="flex-group">
+            <article className="flex-group flex-center">
                 <EstimatedHashGraph />
                 <CirculatingTokenGraph />
                 <TargetDifficultyGraph />

--- a/src/scss/_flex.scss
+++ b/src/scss/_flex.scss
@@ -48,3 +48,9 @@
         }
     }
 }
+@media only screen and (min-width: _breakpoint(step-five)) {
+    .flex-group {
+      max-width: 1900px;
+      margin: 0 auto;
+      }
+    }

--- a/src/scss/_graph.scss
+++ b/src/scss/_graph.scss
@@ -1,8 +1,14 @@
 .graphWrapper {
-    max-width: 85vw;
-    padding: 2rem;
+    width: 90%;
+    max-width: 400px;
+    padding: 25px;
 }
 
+@media (min-width: _breakpoint(step-five)) {
+  .graphWrapper {
+      max-width: 30%;
+  }
+}
 .networkDifficultyPaths,
 .circulateSimpleBars {
     overflow: overlay;


### PR DESCRIPTION
Changed alignment of graphs on homepage to fit into 3 columns on smaller screen widths